### PR TITLE
Fix use of closed network connection and automatically reconnecting

### DIFF
--- a/client.go
+++ b/client.go
@@ -13,11 +13,11 @@ import (
 )
 
 const (
-	DISCONNECTING 	= 0
-	DISCONNECTED 	= 1
-	CONNECTING		= 2
-	CONNECTED		= 3
-	RECONNECTING	= 4
+	DISCONNECTED 	= iota
+	DISCONNECTING
+	CONNECTED
+	CONNECTING
+	RECONNECTING
 )
 
 type ConnectionListener interface {

--- a/client.go
+++ b/client.go
@@ -175,6 +175,7 @@ func (c *Client) status(status int) {
 
 // Connect attempts to connect the client to the server.
 func (c *Client) Connect() error {
+	c.status(CONNECTING)
 	ws, err := websocket.Dial(c.url, "", c.origin)
 	if err != nil {
 		c.Close()

--- a/client.go
+++ b/client.go
@@ -16,6 +16,7 @@ const (
 	DISCONNECTED 	= iota
 	DISCONNECTING
 	CONNECTED
+	DALLING
 	CONNECTING
 	RECONNECTING
 )
@@ -175,7 +176,7 @@ func (c *Client) status(status int) {
 
 // Connect attempts to connect the client to the server.
 func (c *Client) Connect() error {
-	c.status(CONNECTING)
+	c.status(DALLING)
 	ws, err := websocket.Dial(c.url, "", c.origin)
 	if err != nil {
 		c.Close()
@@ -209,6 +210,7 @@ func (c *Client) Reconnect() {
 	c.reconnects++
 
 	// Reconnect
+	c.status(RECONNECTING)
 	ws, err := websocket.Dial(c.url, "", c.origin)
 	if err != nil {
 		c.Close()

--- a/client.go
+++ b/client.go
@@ -16,7 +16,7 @@ const (
 	DISCONNECTED 	= iota
 	DISCONNECTING
 	CONNECTED
-	DALLING
+	DIALING
 	CONNECTING
 	RECONNECTING
 )
@@ -176,7 +176,7 @@ func (c *Client) status(status int) {
 
 // Connect attempts to connect the client to the server.
 func (c *Client) Connect() error {
-	c.status(DALLING)
+	c.status(DIALING)
 	ws, err := websocket.Dial(c.url, "", c.origin)
 	if err != nil {
 		c.Close()

--- a/client.go
+++ b/client.go
@@ -123,8 +123,6 @@ func NewClient(url, origin string) *Client {
 		collections:       map[string]Collection{},
 		url:               url,
 		origin:            origin,
-		// inbox:             make(chan map[string]interface{}, 100),
-		// errors:           make(chan error, 100),
 		pings:             map[string][]*PingTracker{},
 		calls:             map[string]*Call{},
 		subs:              map[string]*Call{},

--- a/collection.go
+++ b/collection.go
@@ -114,7 +114,7 @@ func (c *KeyCache) notify(operation, id string, doc Update) {
 	c.mux.RLock()
 	defer c.mux.RUnlock()
 	for _, listener := range c.listeners {
-		listener.CollectionUpdate(c.Name, operation, id, doc)
+		go listener.CollectionUpdate(c.Name, operation, id, doc)
 	}
 }
 


### PR DESCRIPTION
When I use `client.Close()` I expect to close the connection and don't reconnect. Also, all go workers should be stopped for a clean exit.

I had to simplify my implementation. No guarantee if this doesn't work:
```go
package main

import (
	"time"
	ddp "https://github.com/gopackage/ddp"
)

type event struct {}

func (e *event) Status(status int) {
	var st Status
	switch status {
		case ddp.CONNECTING:
			st = "connecting"
		case ddp.CONNECTED:
			st = "connected"
		case ddp.DISCONNECTED:
			st = "disconnected"
		default:
			st = "disconnected"
	}

	fmt.Println(st)
}

func main() {
	//Create ddp CLient
	ddpClient := ddp.NewClient("wss://example.com/html5client/websocket", "https://example.com/html5client/")

	ddpClient.AddStatusListener(event{}) //Add event listener for status

	ddpClient.Connect()	//Connect to server

	//Do stuff(sub, ...)
	time.Sleep(10 * time.Second) //wait

	ddpClient.Close() //Disconnect from server

	time.Sleep(10 * time.Second) //wait
}
```

After Disconnecting (`client.Close()`) it throws this warning and tries automatically to reconnect:
```
disconnected
2023/01/09 16:35:41  warn Websocket error           error=read tcp [XXXX:XXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:58912->[XXXX:XXX:XXXX:XXXX:XXXX:XXXX:XXXX:XXXX]:443: use of closed network connection
connecting
connected
```



Now this is just a quick fix. I didn't test it with other cases!

Explanation:

1.  I added more connection statuses
2. `inbox` and `errors` channel will be created, when `ddpClient.Connect()` is called. (Performance)
3. `ddpClient.Close()` will close the channel `inbox` and `errors`.
4. All workers will be stopped when closing the channels and changing the status to `DISCONNECTED `. Before the workers were still running even if  `ddpClient.Close()` was called or the object was set to nil (`ddpClient = nil`)
5. The `inboxManager` has now a for loop which only reacts to new incoming messages (`for msg := range c.inbox {`)
6. `errors` now have their own `errorManager()`